### PR TITLE
Missing argument when checking default directory

### DIFF
--- a/helm-rg.el
+++ b/helm-rg.el
@@ -1750,7 +1750,7 @@ The buffer has already been advanced to the appropriate line."
   (pcase-exhaustive default-directory-spec
     ('default default-directory)
     ('git-root (helm-rg--get-git-root))
-    ((pred stringp) (helm-rg--check-directory-path))))
+    ((pred stringp) (helm-rg--check-directory-path default-directory-spec))))
 
 (defun helm-rg--set-case-sensitivity ()
   (interactive)


### PR DESCRIPTION
I tried to have helm-rg open with a specific default directory doing something like this
```
(defun run-rg-in-specific-dir()
  (interactive)`
  (let ((helm-rg-default-directory "<some path>"))`
    (helm-rg "")))
```
but got an `Wrong number of arguments` error.
I tracked it down to the `helm-rg--interpret-starting-dir` function with seems to be missing an argument.
So i added it :)