### PR TITLE
Fix errors when setting extra args twice within a session

### DIFF
--- a/helm-rg.el
+++ b/helm-rg.el
@@ -2271,7 +2271,8 @@ will be split!"
     (split-string-and-unquote
      (or arg-str
          (read-string
-          "rg extra args: " helm-rg--extra-args 'helm-rg--extra-args-history)))))
+          "rg extra args: " (combine-and-quote-strings helm-rg--extra-args)
+          'helm-rg--extra-args-history)))))
 
 (defun helm-rg--set-dir ()
   "Set the directory in which to invoke ripgrep and search again."


### PR DESCRIPTION
We're treating this list as a string for the read-string call here, recombine/quote it for user editing.

This fixes editing args twice within a session, or editing them once when using `helm-rg-default-extra-args`, which similarly poisons the variable for future edits.