### PR TITLE
Fix display of arrow keys in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Also check out [rg.el](https://github.com/dajva/rg.el), which I haven't used muc
 - Use <kbd>M-g</kbd> to input a glob pattern to filter files by, e.g. `*.py`.
     - The glob pattern defaults to the value of `helm-rg-default-glob-string`, which is an empty string (matches every file) unless you customize it.
     - Pressing <kbd>M-g</kbd> again shows the same minibuffer prompt for the glob pattern, with the string that was previously input.
-- Use <kbd><left></kbd> and <kbd><right></kbd> to go up and down by files in the results.
-    - <kbd><up></kbd> and <kbd><down></kbd> simply go up and down by match result, and there may be many matches for your pattern in a single file, even multiple on a single line (which `ripgrep` reports as multiple separate results).
-    - The <kbd><left></kbd> and <kbd><right></kbd> keys will move up or down until it lands on a result from a different file than it started on.
+- Use <kbd>left</kbd> and <kbd>right</kbd> to go up and down by files in the results.
+    - <kbd>up</kbd> and <kbd>down</kbd> simply go up and down by match result, and there may be many matches for your pattern in a single file, even multiple on a single line (which `ripgrep` reports as multiple separate results).
+    - The <kbd>left</kbd> and <kbd>right</kbd> keys will move up or down until it lands on a result from a different file than it started on.
         - When moving by file, `helm-rg` will cycle around the results list, but it will print a harmless error message instead of looping infinitely if all results are from the same file.
 - Use the interactive autoloaded function `helm-rg-display-help` to see the ripgrep command's usage info.
 


### PR DESCRIPTION
Fix how GitHub renders up/down/left/right keys in README.md

### Before
<img width="833" alt="image" src="https://user-images.githubusercontent.com/107841/218300837-d3c722a2-3789-4069-9279-603dd77a1808.png">

### After
<img width="854" alt="image" src="https://user-images.githubusercontent.com/107841/218300861-374c9f43-608d-466b-b89c-13015488877c.png">

Thank you for making this awesome project!