### PR TITLE
Hide ripgrep command in Helm header by default

### DIFF
--- a/helm-rg.el
+++ b/helm-rg.el
@@ -658,6 +658,13 @@ Set to the empty string to match every file."
   :safe #'helm-rg--always-safe-local
   :group 'helm-rg)
 
+(defcustom helm-rg-show-command-line nil
+  "Whether to show the full ripgrep command line in the Helm header.
+When nil, only shows basic information. Set to t to show the full command for debugging."
+  :type 'boolean
+  :safe #'helm-rg--always-safe-local
+  :group 'helm-rg)
+
 (defcustom helm-rg-default-extra-args nil
   "Extra arguments passed to ripgrep on the command line.
 Note that default filename globbing and case sensitivity can be set with their own defcustoms, and
@@ -1136,7 +1143,9 @@ functions."
                      :command argv
                      :noquery t))
          (helm-src-name
-          (format "argv: %s" (helm-rg--join " " argv))))
+          (if helm-rg-show-command-line
+              (format "argv: %s" (helm-rg--join " " argv))
+            "search results")))
     (helm-set-attr 'name helm-src-name)
     (set-process-query-on-exit-flag real-proc nil)
     real-proc))

--- a/helm-rg.el
+++ b/helm-rg.el
@@ -673,8 +673,8 @@ particular ripgrep option and set of options."
   "Specification for starting directory to invoke ripgrep in.
 Used in `helm-rg--interpret-starting-dir'. Possible values:
 
-'default => Use `default-directory'.
-'git-root => Use \"git rev-parse --show-toplevel\" (see
+\='default => Use `default-directory'.
+\='git-root => Use \"git rev-parse --show-toplevel\" (see
              `helm-rg-git-executable').
 <string> => Use the directory at path <string>."
   :type '(choice symbol string)

--- a/helm-rg.el
+++ b/helm-rg.el
@@ -1069,7 +1069,7 @@ any results."
                   (helm-rg--make-face 'helm-rg-error-message "no results for input")
                   (helm-rg--make-face 'font-lock-string-face input-repr)
                   (helm-rg--make-face 'helm-rg-error-message err-msg))))
-    (helm-attrset 'name helm-src-name)
+    (helm-set-attr 'name helm-src-name)
     dummy-proc))
 
 (defun helm-rg--validate-or-make-dummy-process (input)
@@ -1137,7 +1137,7 @@ functions."
                      :noquery t))
          (helm-src-name
           (format "argv: %s" (helm-rg--join " " argv))))
-    (helm-attrset 'name helm-src-name)
+    (helm-set-attr 'name helm-src-name)
     (set-process-query-on-exit-flag real-proc nil)
     real-proc))
 

--- a/helm-rg.el
+++ b/helm-rg.el
@@ -1463,7 +1463,7 @@ TODO: add ert testing for this function!"
 
 (defun helm-rg--current-line-contents ()
   "`helm-current-line-contents' doesn't keep text properties."
-  (buffer-substring (point-at-bol) (point-at-eol)))
+  (buffer-substring (line-beginning-position) (line-end-position)))
 
 (cl-defun helm-rg--nullable-states-different (a b &key (cmp #'eq))
   "Compare A and B respecting nullability using CMP.

--- a/tests/helm-rg-test.el
+++ b/tests/helm-rg-test.el
@@ -11,6 +11,8 @@
 (require 'cl-lib)
 (require 'ert)
 
+(defvar helm-rg-show-command-line)
+
 (defconst helm-rg-test--cwd
   (-> (or load-file-name buffer-file-name) (file-name-directory) (expand-file-name)))
 
@@ -101,3 +103,31 @@
         (helm-rg-test--assert-current-line match-line-in-file)))
     (helm-rg-test--in-test-dir
      (helm-rg-from-isearch))))
+
+(helm-rg-test--define-interactive-test test-helm-rg/show-command-line-option
+  "Test that the command line display option works correctly."
+  (let ((original-value helm-rg-show-command-line)
+        (source-name-1 nil)
+        (source-name-2 nil))
+    (unwind-protect
+        (progn
+          ;; Test with command line hidden
+          (setq helm-rg-show-command-line nil)
+          (helm-rg-test--delayed-do
+            (progn
+              (setq source-name-1 (assoc-default 'name (helm-get-current-source)))
+              (helm-keyboard-quit)))
+          (helm-rg-test--invoke-in-test-dir "test")
+
+          (should (string-match-p "search results" source-name-1))
+
+          ;; Test with command line shown
+          (setq helm-rg-show-command-line t)
+          (helm-rg-test--delayed-do
+            (progn
+              (setq source-name-2 (assoc-default 'name (helm-get-current-source)))
+              (helm-keyboard-quit)))
+          (helm-rg-test--invoke-in-test-dir "test")
+
+          (should (string-match-p "argv:" source-name-2)))
+      (setq helm-rg-show-command-line original-value))))

--- a/tests/helm-rg-test.el
+++ b/tests/helm-rg-test.el
@@ -70,7 +70,7 @@
   "Test that the right file is visited when resuming a `helm-rg' session with `helm-resume'."
   (helm-rg-test--delayed-do
    (helm-keyboard-quit))
-  (with-helm-quittable
+  (with-local-quit
     (helm-rg-test--find-gpl))
   (let ((helm-rg-buf helm-last-buffer))
     (sit-for helm-rg-test--time-step)

--- a/tests/helm-rg-test.el
+++ b/tests/helm-rg-test.el
@@ -63,7 +63,7 @@
 
 (defun helm-rg-test--assert-current-line (line)
   "Assert the contents of the current line, either in the `helm-rg' buffer, or in a matched file."
-  (let ((cur-line (buffer-substring (point-at-bol) (point-at-eol))))
+  (let ((cur-line (buffer-substring (line-beginning-position) (line-end-position))))
     (should (equal cur-line line))))
 
 (helm-rg-test--define-interactive-test test-helm-rg/helm-resume


### PR DESCRIPTION
When the `helm-rg--extra-args` list is too long, the full command takes up a large portion of the Helm minibuffer, which is too noisy. For example:
<img width="1920" height="483" alt="2025-07-16-120135_1920x483_scrot" src="https://github.com/user-attachments/assets/b22bf4ab-cf05-4c2e-8ddd-459ad6451c39" />

This hides the command by default and shows `search results @ <directory>` instead:
<img width="1920" height="483" alt="2025-07-16-125622_1920x483_scrot" src="https://github.com/user-attachments/assets/7805a9d7-94bd-40ba-9627-bfd3fce96dd9" />

It also adds a customize option `helm-rg-show-command-line` which brings back the previous behavior if it's not nil.

Full disclosure: this was done with the help of Claude Sonnet 4, but I reviewed the code and tested it to be working as expected on Emacs 30.1 and Helm 4.0.4. An interactive test was also added, which passes after some compatibility fixes with Emacs 30.1 (see #44).

This is based on #44, so that should be merged first. I'm not able to change the base branch for this PR, which is why it's showing the changes from both branches, but only the top-most commit is relevant.

Closes #31, #42