### PR TITLE
Fix compatibility issues with recent Emacs versions

### DIFF
--- a/helm-rg.el
+++ b/helm-rg.el
@@ -673,8 +673,8 @@ particular ripgrep option and set of options."
   "Specification for starting directory to invoke ripgrep in.
 Used in `helm-rg--interpret-starting-dir'. Possible values:
 
-'default => Use `default-directory'.
-'git-root => Use \"git rev-parse --show-toplevel\" (see
+\='default => Use `default-directory'.
+\='git-root => Use \"git rev-parse --show-toplevel\" (see
              `helm-rg-git-executable').
 <string> => Use the directory at path <string>."
   :type '(choice symbol string)

--- a/helm-rg.el
+++ b/helm-rg.el
@@ -1069,7 +1069,7 @@ any results."
                   (helm-rg--make-face 'helm-rg-error-message "no results for input")
                   (helm-rg--make-face 'font-lock-string-face input-repr)
                   (helm-rg--make-face 'helm-rg-error-message err-msg))))
-    (helm-attrset 'name helm-src-name)
+    (helm-set-attr 'name helm-src-name)
     dummy-proc))
 
 (defun helm-rg--validate-or-make-dummy-process (input)
@@ -1137,7 +1137,7 @@ functions."
                      :noquery t))
          (helm-src-name
           (format "argv: %s" (helm-rg--join " " argv))))
-    (helm-attrset 'name helm-src-name)
+    (helm-set-attr 'name helm-src-name)
     (set-process-query-on-exit-flag real-proc nil)
     real-proc))
 

--- a/helm-rg.el
+++ b/helm-rg.el
@@ -1463,7 +1463,7 @@ TODO: add ert testing for this function!"
 
 (defun helm-rg--current-line-contents ()
   "`helm-current-line-contents' doesn't keep text properties."
-  (buffer-substring (point-at-bol) (point-at-eol)))
+  (buffer-substring (line-beginning-position) (line-end-position)))
 
 (cl-defun helm-rg--nullable-states-different (a b &key (cmp #'eq))
   "Compare A and B respecting nullability using CMP.

--- a/tests/helm-rg-test.el
+++ b/tests/helm-rg-test.el
@@ -70,7 +70,7 @@
   "Test that the right file is visited when resuming a `helm-rg' session with `helm-resume'."
   (helm-rg-test--delayed-do
    (helm-keyboard-quit))
-  (with-helm-quittable
+  (with-local-quit
     (helm-rg-test--find-gpl))
   (let ((helm-rg-buf helm-last-buffer))
     (sit-for helm-rg-test--time-step)

--- a/tests/helm-rg-test.el
+++ b/tests/helm-rg-test.el
@@ -63,7 +63,7 @@
 
 (defun helm-rg-test--assert-current-line (line)
   "Assert the contents of the current line, either in the `helm-rg' buffer, or in a matched file."
-  (let ((cur-line (buffer-substring (point-at-bol) (point-at-eol))))
+  (let ((cur-line (buffer-substring (line-beginning-position) (line-end-position))))
     (should (equal cur-line line))))
 
 (helm-rg-test--define-interactive-test test-helm-rg/helm-resume


### PR DESCRIPTION
I ran into some issues when attempting to run the interactive tests on Emacs 30.1. See the commits for details.

This does mean that the package likely won't work in Emacs <29.1, or with older versions of Helm. I tested it with Emacs 30.1 and Helm 20250716.528 (03dd33339cf9, helm-core 4.0.4).

Considering this package is not maintained, I don't expect this to be merged, but maybe it will be useful for future maintainers.